### PR TITLE
 RDKE-206 Logrotate changes to RDK-E

### DIFF
--- a/systemd_units/logrotate.service
+++ b/systemd_units/logrotate.service
@@ -21,5 +21,7 @@
 Description=Log Rotation Timer Service (R)
 
 [Service]
+Type=forking
 SyslogIdentifier=logrotate
-ExecStart=/lib/rdk/logRotateDaemon.sh
+ExecStart=/usr/sbin/logrotate -s /tmp/logrotatedata.status /etc/logrotatedata.conf
+Restart=always


### PR DESCRIPTION
RDKE-206 Logrotate changes to RDK-E
Reason for change: Replacing log rotate opensource tool instead of daemon script Test Procedure: Test the logrotate functionality for the various module logs Risks: None
Priority: P2
Signed-off-by: Vismal S Kumar <VismalSasi_Kumar@comcast.com>