### PR TITLE
DELIA-66971,DELIA-66972: Newly add processes to be captured upon crash

### DIFF
--- a/lib/rdk/core_shell.sh
+++ b/lib/rdk/core_shell.sh
@@ -320,7 +320,7 @@ if  [ "$1" = "xcal-discovery-" ] || [ "$1" = "xdiscovery" ] || [ "$1" = "IARMDae
     [ "$1" = "dvrsrc:src" ] || [ "$1" = "qsrc:src" ] ||
     [ "$1" = "qamsrc_bin-queu" ] || [ "$1" = "authservice" ] || [ "$1" = "named" ] ||
     [ "$1" = "slave_callback" ]  || [ "$1" = "telemetry2_0" ] || [ "$1" = "WorkerPool::Thr" ]
-    [ "$1" = "subttxrend-app" ] || [ "$1" = "logrotate" ]; then
+    [ "$1" = "subttxrend-app" ] || [ "$1" = "logrotate" ] || [ "$1" = "NetworkManager" ] || [ "$1" = "Monitor::IResou" ]; then
         dumpFile
         exit 0
 fi


### PR DESCRIPTION
Reason for change: Core dump is not generated when `NetworkManager` & `Monitor::IResou` Processes get crashed.
So added the `NetworkManager` process to be captured upon crash. We have seen instances where WPEFramework Crash is happening but the process name is identified as `Monitor::IResou`; Added that as well to upload
Test Procedure: Verify in NG build
Risks: Medium