### PR TITLE
RDKE-469: enable SSH on 22 for community builds

### DIFF
--- a/lib/rdk/iptables_init
+++ b/lib/rdk/iptables_init
@@ -242,11 +242,6 @@ if [ -x $IPV6_BIN_PATH ]; then
 
     $IPV6_BIN -A StaticSnmpV2WhiteList -j SNMPEndOfListV6
     $IPV6_BIN -A StaticSnmpV3WhiteList -j SNMPEndOfListV6
-
-    ## Enable SSH for community DEV builds.
-    if [ "${COMMUNITY_BUILDS}" = "true" ] && [ "${BUILD_TYPE}" = "dev" ]; then
-        $IPV6_BIN -I INPUT -p tcp --dport 22 -j ACCEPT
-    fi
 else
     ipTableLogging "$IPV6_BIN_PATH not found OR box is in IPv4 mode - did not apply ip6tables rules"
 fi


### PR DESCRIPTION
Reason for Change: enable SSH suppoprt for testing in middleware onwards. Allow port 22 connection when COMMUNITY_BUILD and BUILD_TYPE is DEV.
Test Procedure: SSH should work on port 22 when COMMUNITY_BUILD is true and BUILD_TYPE is DEV