### PR TITLE
RDK-49890 Downloadable xpki certs

### DIFF
--- a/lib/rdk/factory-reset.sh
+++ b/lib/rdk/factory-reset.sh
@@ -131,6 +131,10 @@ fi
 # RFC data cleanup
 if [ -d /opt/RFC ]; then rm -rf /opt/RFC; fi
 if [ -d /opt/secure/RFC ]; then rm -rf /opt/secure/RFC; fi
+# Downloadable certs cleanup
+if [ -d /opt/dl/certs ]; then rm -rf /opt/dl/certs; fi
+# Downloadable creds cleanup
+if [ -d /opt/dl/lxy ]; then rm -rf /opt/dl/lxy; fi
 
 # clear systemd settings
 if [ -d /opt/systemd ]; then rm -rf /opt/systemd; fi

--- a/lib/rdk/warehouse-reset.sh
+++ b/lib/rdk/warehouse-reset.sh
@@ -170,6 +170,10 @@ if [ -d /opt/lib/bluetooth ]; then rm -rf /opt/lib/bluetooth; fi
 # RFC data cleanup
 if [ -d /opt/RFC ]; then rm -rf /opt/RFC; fi
 if [ -d /opt/secure/RFC ]; then rm -rf /opt/secure/RFC; fi
+# Downloadable certs cleanup
+if [ -d /opt/dl/certs ]; then rm -rf /opt/dl/certs; fi
+# Downloadable creds cleanup
+if [ -d /opt/dl/lxy ]; then rm -rf /opt/dl/lxy; fi
 #Removing the tmpfs files from XCONF
 rm -rf /tmp/device_initiated_snmp_cdl_in_progress
 rm -rf /tmp/device_initiated_rcdl_in_progress


### PR DESCRIPTION
Reason for change: Cleanup RDM certs upon factory reset
Test Procedure: Build and verify connectivity to end-points
Risks: None
Priority: P1

Change-Id: I192afe6f6b69b52dc9b54a120547c8439c3ca95d
Signed-off-by: Vinothkumar <vinothkumar_baskaran@comcast.com>
(cherry picked from commit 66b31cfad82db19eb439b119fcf3bff045a90d4a) (cherry picked from commit 3fd993cf8037e64e3bac0f8d7822f337a9f71965)