### PR TITLE
RDKEMW-1929: [RDKE][XUMO]-Unable to REVSSH to Device

### DIFF
--- a/lib/rdk/NM_Bootstrap.sh
+++ b/lib/rdk/NM_Bootstrap.sh
@@ -27,16 +27,29 @@ if [ -f $WIFI_WPA_SUPPLICANT_CONF ]; then
 
   ETH_STATUS=$(nmcli dev status | grep -w eth0)
   IS_ETH_CONN=$(echo $ETH_STATUS | grep -w connected)
-  WIFI_STATUS=$(nmcli dev status | grep -w wlan0)
-  IS_WIFI_CONN=$(echo $WIFI_STATUS | grep -w connected)
 
   if [ -z "${IS_ETH_CONN}" ]; then
-          if [ -z "${IS_WIFI_CONN}" ]; then
-            if [ -z "$( ls -A '/etc/NetworkManager/system-connections' )" ]; then
-                  #connect to wifi
-                  nmcli conn add type wifi con-name $SSID autoconnect yes ifname wlan0 ssid $SSID wifi-sec.key-mgmt wpa-psk wifi-sec.psk $PSK 
-                  nmcli conn reload
+         if [ -z "$( ls -A '/opt/NetworkManager/system-connections' )" ]; then
+            if [ -z $PSK ]; then
+                #connect to wifi
+                nmcli conn add type wifi con-name $SSID autoconnect yes ifname wlan0 ssid $SSID
+                nmcli conn reload
+            else
+                #connect to wifi
+                nmcli conn add type wifi con-name $SSID autoconnect yes ifname wlan0 ssid $SSID wifi-sec.key-mgmt wpa-psk wifi-sec.psk $PSK
+                nmcli conn reload
             fi
-          fi
+         elif [ -z $(grep "interface-name" /opt/NetworkManager/system-connections/*.nmconnection) ]; then
+            rm -rf /opt/NetworkManager/system-connections/*.nmconnection
+            if [ -z $PSK ]; then
+                #connect to wifi
+                nmcli conn add type wifi con-name $SSID autoconnect yes ifname wlan0 ssid $SSID
+                nmcli conn reload
+            else
+                #connect to wifi
+                nmcli conn add type wifi con-name $SSID autoconnect yes ifname wlan0 ssid $SSID wifi-sec.key-mgmt wpa-psk wifi-sec.psk $PSK
+                nmcli conn reload
+            fi
+         fi
   fi
 fi


### PR DESCRIPTION
Reason for change: Move bootstrap script to Middleware
Test Procedure: Build RDKE image

Signed-off-by: [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)