### PR TITLE
RDKE-728: Move NetworkManager Dispatcher scripts to Middleware

### DIFF
--- a/lib/rdk/NM_Dispatcher.sh
+++ b/lib/rdk/NM_Dispatcher.sh
@@ -54,8 +54,11 @@ if [ "x$interfaceName" != "x" ] && [ "$interfaceName" != "lo" ]; then
 
         sh -x /lib/rdk/updateGlobalIPInfo.sh "add" $mode $interfaceName $ipaddr "global"
         echo "$DT_TIME updateGlobalIPInfo.sh" >> /opt/logs/NMMonitor.log
-             
+
         sh /lib/rdk/ipmodechange.sh $imode $interfaceName $ipaddr $gwip $interfaceName "metric" "add"
         echo "$DT_TIME ipmodechange.sh" >> /opt/logs/NMMonitor.log
+    fi
+    if [ "$interfaceName" == "wlan0" ]; then
+        touch /tmp/wifi-on
     fi
 fi

--- a/lib/rdk/NM_Dispatcher.sh
+++ b/lib/rdk/NM_Dispatcher.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+####################################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2024 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+####################################################################################
+
+DT_TIME=$(date +'%Y-%m-%d:%H:%M:%S:%6N')
+echo "$DT_TIME From NM_Dispatcher.sh $1 $2" >> /opt/logs/NM_dispatcher.txt
+
+interfaceName=$1
+interfaceStatus=$2
+
+if [ "x$interfaceName" != "x" ] && [ "$interfaceName" != "lo" ]; then
+    if [ "$interfaceStatus" == "dhcp4-change" ]; then
+        mode="ipv4"
+        gwip=$(/sbin/ip -4 route | awk '/default/ { print $3 }' | head -n1 | awk '{print $1;}')
+        imode=2
+        ipaddr=$(ifconfig $interfaceName | grep -w inet | awk -F ' ' '{print $2}' | awk -F ':' '{print $2}')
+    elif [ "$interfaceStatus" == "dhcp6-change" ]; then
+        mode="ipv6"
+        ipaddr=$(ifconfig $interfaceName | grep -w inet6 | grep Global | awk -F " " '{print $3}' | tail -n1 | cut -d '/' -f1)
+        imode=10
+        gwip=$(/sbin/ip -6 route | awk '/default/ { print $3 }' | head -n1 | awk '{print $1;}')
+    fi
+
+    if [ "$interfaceStatus" == "dhcp6-change" ] || [ "$interfaceStatus" == "dhcp4-change" ]; then
+
+        sh /lib/rdk/networkLinkEvent.sh $interfaceName "add"
+        echo "$DT_TIME networkLinkEvent.sh" >> /opt/logs/NM_dispatcher.txt
+
+        sh /lib/rdk/ipv6addressChange.sh "add" $mode $interfaceName $ipaddr "global"
+        echo "$DT_TIME ipv6addressChange.sh" >> /opt/logs/NM_dispatcher.txt
+
+        sh /lib/rdk/networkInfoLogger.sh "add" $mode $interfaceName $ipaddr "global"
+        echo "$DT_TIME networkInfoLogger.sh" >> /opt/logs/NM_dispatcher.txt
+
+        sh /lib/rdk/checkDefaultRoute.sh  $imode $interfaceName $ipaddr $gwip $interfaceName "metric" "add"
+        echo "$DT_TIME checkDefaultRoute.sh" >> /opt/logs/NM_dispatcher.txt
+
+        sh -x /lib/rdk/updateGlobalIPInfo.sh "add" $mode $interfaceName $ipaddr "global"
+        echo "$DT_TIME updateGlobalIPInfo.sh" >> /opt/logs/NM_dispatcher.txt
+             
+        sh /lib/rdk/ipmodechange.sh $imode $interfaceName $ipaddr $gwip $interfaceName "metric" "add"
+        echo "$DT_TIME ipmodechange.sh" >> /opt/logs/NM_dispatcher.txt
+    fi
+fi

--- a/lib/rdk/NM_Dispatcher.sh
+++ b/lib/rdk/NM_Dispatcher.sh
@@ -20,7 +20,7 @@
 ####################################################################################
 
 DT_TIME=$(date +'%Y-%m-%d:%H:%M:%S:%6N')
-echo "$DT_TIME From NM_Dispatcher.sh $1 $2" >> /opt/logs/NM_dispatcher.txt
+echo "$DT_TIME From NM_Dispatcher.sh $1 $2" >> /opt/logs/NMMonitor.log
 
 interfaceName=$1
 interfaceStatus=$2
@@ -41,21 +41,21 @@ if [ "x$interfaceName" != "x" ] && [ "$interfaceName" != "lo" ]; then
     if [ "$interfaceStatus" == "dhcp6-change" ] || [ "$interfaceStatus" == "dhcp4-change" ]; then
 
         sh /lib/rdk/networkLinkEvent.sh $interfaceName "add"
-        echo "$DT_TIME networkLinkEvent.sh" >> /opt/logs/NM_dispatcher.txt
+        echo "$DT_TIME networkLinkEvent.sh" >> /opt/logs/NMMonitor.log
 
         sh /lib/rdk/ipv6addressChange.sh "add" $mode $interfaceName $ipaddr "global"
-        echo "$DT_TIME ipv6addressChange.sh" >> /opt/logs/NM_dispatcher.txt
+        echo "$DT_TIME ipv6addressChange.sh" >> /opt/logs/NMMonitor.log
 
         sh /lib/rdk/networkInfoLogger.sh "add" $mode $interfaceName $ipaddr "global"
-        echo "$DT_TIME networkInfoLogger.sh" >> /opt/logs/NM_dispatcher.txt
+        echo "$DT_TIME networkInfoLogger.sh" >> /opt/logs/NMMonitor.log
 
         sh /lib/rdk/checkDefaultRoute.sh  $imode $interfaceName $ipaddr $gwip $interfaceName "metric" "add"
-        echo "$DT_TIME checkDefaultRoute.sh" >> /opt/logs/NM_dispatcher.txt
+        echo "$DT_TIME checkDefaultRoute.sh" >> /opt/logs/NMMonitor.log
 
         sh -x /lib/rdk/updateGlobalIPInfo.sh "add" $mode $interfaceName $ipaddr "global"
-        echo "$DT_TIME updateGlobalIPInfo.sh" >> /opt/logs/NM_dispatcher.txt
+        echo "$DT_TIME updateGlobalIPInfo.sh" >> /opt/logs/NMMonitor.log
              
         sh /lib/rdk/ipmodechange.sh $imode $interfaceName $ipaddr $gwip $interfaceName "metric" "add"
-        echo "$DT_TIME ipmodechange.sh" >> /opt/logs/NM_dispatcher.txt
+        echo "$DT_TIME ipmodechange.sh" >> /opt/logs/NMMonitor.log
     fi
 fi

--- a/lib/rdk/NM_preDown.sh
+++ b/lib/rdk/NM_preDown.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+####################################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2024 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+####################################################################################
+
+DT_TIME=$(date +'%Y-%m-%d:%H:%M:%S:%6N')
+echo "$DT_TIME From NM_Dispatcher.sh $1 $2" >> /opt/logs/NMMonitor.log
+
+interfaceName=$1
+interfaceStatus=$2
+
+if [ "x$interfaceName" != "x" ] && [ "$interfaceName" != "lo" ]; then
+        if [ "$interfaceName" == "wlan0" ]; then
+                rm /tmp/wifi-on
+        fi
+        mode4="ipv4"
+        gwip4=$(/sbin/ip -4 route | awk '/default/ { print $3 }' | head -n1 | awk '{print $1;}')
+        imode4=2
+        ipaddr4=$(ifconfig $interfaceName | grep -w inet | awk -F ' ' '{print $2}' | awk -F ':' '{print $2}')
+        echo "IPADDR4 = $ipaddr4" >> /opt/logs/NMMonitor.log
+        mode6="ipv6"
+        ipaddr6=$(ifconfig $interfaceName | grep -w inet6 | grep Global | awk -F " " '{print $3}' | tail -n1 | cut -d '/' -f1)
+        echo "IPADDR6 = $ipaddr6" >> /opt/logs/NMMonitor.log
+        imode6=10
+        gwip6=$(/sbin/ip -6 route | awk '/default/ { print $3 }' | head -n1 | awk '{print $1;}')
+
+
+        sh /lib/rdk/networkLinkEvent.sh $interfaceName "delete"
+        echo "$DT_TIME networkLinkEvent.sh" >> /opt/logs/NMMonitor.log
+
+        sh /lib/rdk/ipv6addressChange.sh "delete" $mode4 $interfaceName $ipaddr4 "global"
+        sh /lib/rdk/ipv6addressChange.sh "delete" $mode6 $interfaceName $ipaddr6 "global"
+        echo "$DT_TIME ipv6addressChange.sh" >> /opt/logs/NMMonitor.log
+
+        sh /lib/rdk/checkDefaultRoute.sh  $imode4 $interfaceName $ipaddr4 $gwip4 $interfaceName "metric" "delete"
+        sh /lib/rdk/checkDefaultRoute.sh  $imode6 $interfaceName $ipaddr6 $gwip6 $interfaceName "metric" "delete"
+        echo "$DT_TIME checkDefaultRoute.sh" >> /opt/logs/NMMonitor.log
+
+        sh -x /lib/rdk/updateGlobalIPInfo.sh "delete" $mode4 $interfaceName $ipaddr4 "global"
+        sh -x /lib/rdk/updateGlobalIPInfo.sh "delete" $mode6 $interfaceName $ipaddr6 "global"
+        echo "$DT_TIME updateGlobalIPInfo.sh" >> /opt/logs/NMMonitor.log
+
+        sh /lib/rdk/ipmodechange.sh $imode4 $interfaceName $ipaddr4 $gwip4 $interfaceName "metric" "delete"
+        sh /lib/rdk/ipmodechange.sh $imode6 $interfaceName $ipaddr6 $gwip6 $interfaceName "metric" "delete"
+        echo "$DT_TIME ipmodechange.sh" >> /opt/logs/NMMonitor.log
+fi

--- a/lib/rdk/NM_restartConn.sh
+++ b/lib/rdk/NM_restartConn.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+####################################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2024 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+####################################################################################
+
+# Get all connection names associated with the device
+CONNECTIONS=$(nmcli connection show | grep wifi | cut -d ' ' -f1)
+
+# Bring up each connection
+for CONNECTION in $CONNECTIONS; do
+    nmcli connection up "$CONNECTION"
+done

--- a/lib/rdk/start_ssh.sh
+++ b/lib/rdk/start_ssh.sh
@@ -112,7 +112,6 @@ if [ "$DEVICE_TYPE" = "mediaclient" ]; then
            fi
            sleep 5
      done
-     echo "FOUND= $ipAddress"
 
      #Concatenating all ip addresses
      IP_ADDRESS_PARAM=""

--- a/lib/rdk/start_ssh.sh
+++ b/lib/rdk/start_ssh.sh
@@ -37,8 +37,8 @@ if [ -f /etc/mount-utils/getConfigFile.sh ];then
       getConfigFile $DROPBEAR_PARAMS_1
 
       if [ ! -f "$DROPBEAR_PARAMS_1" ]; then
-	echo "Dropbear param 1: $DROPBEAR_PARAMS_1 generation failure"
-	exit 127
+        echo "Dropbear param 1: $DROPBEAR_PARAMS_1 generation failure"
+        exit 127
       fi
 
       getConfigFile $DROPBEAR_PARAMS_2
@@ -65,10 +65,9 @@ checkForInterface()
 {
    interface=$1
    if [ -f /tmp/estb_ipv6 ]; then
-       ipAddress=`ip addr show dev $interface | grep -i global | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\1/;t;d'`
-   else 
-       ipAddress=`ip addr show dev $interface | grep -i global | sed -e's/^.*inet \([^ ]*\)\/.*$/\1/;t;d'`
-  fi
+       ipv6address=`cat /tmp/.ipv6$interface`
+   fi
+   ipv4address=`cat /tmp/.ipv4$interface`
 }
 
 #RFC check for MOCA SSH enable/not.
@@ -80,7 +79,7 @@ if [ "$COMMUNITY_BUILDS" = "true" ]; then
      EXTRA_ARGS=" -B "
      DROPBEAR_KEY_DIR="/opt/dropbear"
      if [ ! -f ${DROPBEAR_KEY_DIR}/dropbear_rsa_host_key ] ; then
-	systemctl start dropbearkey.service
+        systemctl start dropbearkey.service
      fi
      DROPBEAR_PARAMS="${DROPBEAR_KEY_DIR}/dropbear_rsa_host_key"
 else
@@ -94,28 +93,27 @@ if [ "$DEVICE_TYPE" = "mediaclient" ]; then
       do
            if [ "$WIFI_INTERFACE" ] && [ ! "$ipAddress" ];then
                  checkForInterface "$WIFI_INTERFACE"
-                 if [ "$ipAddress" ]; then
-                      ipAddress+=" "
-                      ipAddress+=$(ifconfig $WIFI_INTERFACE | awk '/inet / && !/127.0.0.1/ { sub(/addr:/, "", $2); print $2 }')
-                      break
-                 fi
+                 ipAddress+=" "
+                 ipAddress+=$ipv6address
+                 ipAddress+=" "
+                 ipAddress+=$ipv4address
            fi
            Interface=`getMoCAInterface`
-           if [ ! "$ipAddress" ];then
-                 checkForInterface "$Interface"
+           checkForInterface "$Interface"
+           ipAddress+=" "
+           ipAddress+=$ipv6address
+           ipAddress+=" "
+           ipAddress+=$ipv4address
+           break
 
-                 if [ "$ipAddress" ]; then
-                      ipAddress+=" "
-                      ipAddress+=$(ifconfig $Interface | awk '/inet / && !/127.0.0.1/ { sub(/addr:/, "", $2); print $2 }')
-                      break
-                 fi
-           fi
            if [ "$isMOCASSHEnable" = "true" ];then
                ipAddress+=" "
                ipAddress+=`ifconfig $MOCA_INTERFACE |grep 169.254.* |tr -s ' '| cut -d ' ' -f3 | sed -e 's/addr://g'`
            fi
-	   sleep 5
+           sleep 5
      done
+     echo "FOUND= $ipAddress"
+
      #Concatenating all ip addresses
      IP_ADDRESS_PARAM=""
      for i in $ipAddress;
@@ -144,7 +142,7 @@ startDropbear()
      echo --------- $interface got an ip $ipAddress starting dropbear service ---------
      if [ -f /etc/os-release ];then
           /bin/systemctl set-environment IP_ADDRESS=$ipAddress
-	  if [ "$COMMUNITY_BUILDS" = "true" ]; then
+          if [ "$COMMUNITY_BUILDS" = "true" ]; then
                 /bin/systemctl set-environment DROPBEAR_PARAMS="-r $DROPBEAR_PARAMS"
           else
                 /bin/systemctl set-environment DROPBEAR_PARAMS="-r $DROPBEAR_PARAMS_1 -r $DROPBEAR_PARAMS_2"
@@ -187,7 +185,7 @@ do
                    startDropbear "$estbIp"
                    loop=0
               fi
-	 fi
+         fi
     fi
 done
 

--- a/lib/rdk/updateGlobalIPInfo.sh
+++ b/lib/rdk/updateGlobalIPInfo.sh
@@ -74,3 +74,22 @@ if [ "x$cmd" == "xadd" ] && [ "x$flags" == "xglobal" ]; then
         refresh_devicedetails "boxIP"
     fi
 fi
+
+if [ "x$cmd" == "xdelete" ] && [ "x$flags" == "xglobal" ]; then
+
+    if [[ "$ifc" == "$ESTB_INTERFACE" || "$ifc" == "$DEFAULT_ESTB_INTERFACE" || "$ifc" == "$ESTB_INTERFACE:0" ]]; then
+        check_valid_IPaddress
+        echo "Updating Box/ESTB IP"
+        rm /tmp/.$mode$ESTB_INTERFACE
+        refresh_devicedetails "estb_ip"
+    elif [[ "$ifc" == "$MOCA_INTERFACE" || "$ifc" == "$MOCA_INTERFACE:0" ]]; then
+        echo "Updating MoCA IP"
+        rm /tmp/.$mode$MOCA_INTERFACE
+        refresh_devicedetails "moca_ip"
+    elif [[ "$ifc" == "$WIFI_INTERFACE" || "$ifc" == "$WIFI_INTERFACE:0" ]]; then
+        check_valid_IPaddress
+        echo "Updating Wi-Fi IP"
+        rm /tmp/.$mode$WIFI_INTERFACE
+        refresh_devicedetails "boxIP"
+    fi
+fi


### PR DESCRIPTION
Reason for change: Move NetworkManager Dispatcher scripts to Middleware
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)