### PR TITLE
SERXIONE-7072:Gst registry creation failure

### DIFF
--- a/systemd_units/gstreamer-cleanup.service
+++ b/systemd_units/gstreamer-cleanup.service
@@ -31,7 +31,7 @@ Environment="CDLFILE=$(cat /opt/cdl_flashed_file_name)"
 Environment="PREV_CDLFILE=$(cat /opt/previous_flashed_file_name)"
 Environment="GST_REGISTRY=/opt/.gstreamer/registry.bin"
 ExecStartPre=/bin/sh -c 'if [ -f /lib/rdk/logMilestone.sh ];then sh /lib/rdk/logMilestone.sh "GST_CLEANUP_START"; fi;'
-ExecStart=-/bin/sh -c 'if [[ ${CDLFILE} != *"${PREV_CDLFILE}"* ]]; then echo "Removing gstreamer registry on bootup after CDL"; rm -rf /opt/.gstreamer;GST_REGISTRY_UPDATE=yes gst-inspect-1.0 >/dev/null 2>&1; elif [ ! -f /opt/.gstreamer/registry.bin ]; then echo "Gstreamer registry empty"; rm -rf /opt/.gstreamer; GST_REGISTRY_UPDATE=yes gst-inspect-1.0 >/dev/null 2>&1; else echo "gstreamer registry is not removed, previous reboot is not due to CDL"; fi'
+ExecStart=-/bin/sh -c 'if [[ ! -f /opt/previous_flashed_file_name || ! -f /opt/cdl_flashed_file_name || ${CDLFILE} != *"${PREV_CDLFILE}"* ]]; then echo "Removing gstreamer registry on bootup after CDL"; rm -rf /opt/.gstreamer;GST_REGISTRY_UPDATE=yes gst-inspect-1.0 >/dev/null 2>&1; elif [ ! -f /opt/.gstreamer/registry.bin ]; then echo "Gstreamer registry empty"; rm -rf /opt/.gstreamer; GST_REGISTRY_UPDATE=yes gst-inspect-1.0 >/dev/null 2>&1; else echo "gstreamer registry is not removed, previous reboot is not due to CDL"; fi'
 ExecStartPost=/bin/sh -c 'if [ -f /lib/rdk/logMilestone.sh ];then sh /lib/rdk/logMilestone.sh "GST_CLEANUP_COMPLETE"; fi;'
 ExecStop=/bin/sh -c 'FW_UPDATE_STATE=$(cat /opt/fwdnldstatus.txt | grep FwUpdateState | cut -d "|" -f2); echo "FW_UPDATE_STATE: $FW_UPDATE_STATE"; if [ "$FW_UPDATE_STATE" == "Preparing to reboot" ]; then  echo "Removing gstreamer registry after firmware update"; rm -rf /opt/.gstreamer; fi;'
 


### PR DESCRIPTION
Reason for change:To handle the gst registry creation in case if cdl_flashed_file_name or previous_flashed_file_name is not present
Test Procedure: as per SERXIONE-7072
Signed-off-by: Tony Paul <Tony_Paul@comcast.com>