### PR TITLE
Update NM_restartConn.sh

### DIFF
--- a/lib/rdk/NM_restartConn.sh
+++ b/lib/rdk/NM_restartConn.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set +e
 ####################################################################################
 # If not stated otherwise in this file or this component's LICENSE file the
 # following copyright and licenses apply:
@@ -34,3 +34,4 @@ for CONNECTION in $CONNECTIONS; do
         nmcli conn up $CONNECTION
     fi
 done
+exit 0


### PR DESCRIPTION
Reason for change: Ideally SSID should not have spaces or special character substrings. In case they do, we do not want it to fail due to CLI handling limitations. We can manually connect to such SSIDs once NetworkManager is up. 
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)