### PR TITLE
RDKEMW-3079 : Change the Name of the Out-of-Process Thunder NetworkManager Plugin

### DIFF
--- a/lib/rdk/core_shell.sh
+++ b/lib/rdk/core_shell.sh
@@ -318,9 +318,9 @@ if  [ "$1" = "xcal-discovery-" ] || [ "$1" = "xdiscovery" ] || [ "$1" = "IARMDae
     [ "$1" = "dvrsrc:src" ] || [ "$1" = "qsrc:src" ] ||
     [ "$1" = "qamsrc_bin-queu" ] || [ "$1" = "authservice" ] || [ "$1" = "named" ] ||
     [ "$1" = "slave_callback" ]  || [ "$1" = "telemetry2_0" ] || [ "$1" = "WorkerPool::Thr" ] ||
-    [ "$1" = "subttxrend-app" ] || [ "$1" = "logrotate" ] || [ "$1" = "NWMgrPlugin" ] ||
-    [ "$1" = "NetworkManager" ] || [ "$1" = "nm_event_thrd" ] || [ "$1" = "Monitor::IResou" ] ||
-    [ "$1" = "DRMSYSTEM" ] || [ "$1" = "HTTPREQUEST_MAN" ]; then
+    [ "$1" = "subttxrend-app" ] || [ "$1" = "logrotate" ] || [ "$1" = "NetworkManager" ] || 
+    [ "$1" = "NWMgrPlugin" ] || [ "$1" = "nm_event_thrd" ] ||
+    [ "$1" = "Monitor::IResou" ] || [ "$1" = "DRMSYSTEM" ] || [ "$1" = "HTTPREQUEST_MAN" ]; then
         dumpFile
         exit 0
 fi

--- a/lib/rdk/core_shell.sh
+++ b/lib/rdk/core_shell.sh
@@ -318,8 +318,9 @@ if  [ "$1" = "xcal-discovery-" ] || [ "$1" = "xdiscovery" ] || [ "$1" = "IARMDae
     [ "$1" = "dvrsrc:src" ] || [ "$1" = "qsrc:src" ] ||
     [ "$1" = "qamsrc_bin-queu" ] || [ "$1" = "authservice" ] || [ "$1" = "named" ] ||
     [ "$1" = "slave_callback" ]  || [ "$1" = "telemetry2_0" ] || [ "$1" = "WorkerPool::Thr" ] ||
-    [ "$1" = "subttxrend-app" ] || [ "$1" = "logrotate" ] || [ "$1" = "NetworkManager" ] || 
-    [ "$1" = "Monitor::IResou" ] || [ "$1" = "DRMSYSTEM" ] || [ "$1" = "HTTPREQUEST_MAN" ]; then
+    [ "$1" = "subttxrend-app" ] || [ "$1" = "logrotate" ] || [ "$1" = "NWMgrPlugin" ] ||
+    [ "$1" = "NetworkManager" ] || [ "$1" = "nm_event_thrd" ] || [ "$1" = "Monitor::IResou" ] ||
+    [ "$1" = "DRMSYSTEM" ] || [ "$1" = "HTTPREQUEST_MAN" ]; then
         dumpFile
         exit 0
 fi


### PR DESCRIPTION
Reason for change: Change the Name of the Out-of-Process Thunder NetworkManager Plugin as NWMgrPlugin
Test Procedure: Verify in top -p <PID>
Risks: Low
Priority: P1
Signed-off-by: Gururaaja ESR <gururaja_erodesriranganramlingham@comcast.com>