### PR TITLE
RDKTV-35245 : Delete sqlite temporary data (#121)

### DIFF
--- a/lib/rdk/factory-reset.sh
+++ b/lib/rdk/factory-reset.sh
@@ -77,6 +77,7 @@ if [ -d /tmp/mnt/diska3/persistent ]; then
     find /tmp/mnt/diska3/persistent -mindepth 1 -maxdepth 1 ! -name 'store-mode-video' -exec rm -rf {} \;
 fi
 rm -rf /opt/secure/persistent/rdkservicestore
+rm -rf /opt/secure/persistent/rdkservicestore-journal
 rm -rf /opt/secure/persistent/System
 
 # authservice data cleanup

--- a/lib/rdk/warehouse-reset.sh
+++ b/lib/rdk/warehouse-reset.sh
@@ -148,6 +148,7 @@ fi
 rm -rf /opt/secure/persistent/System
 if [ ! -f /tmp/warehouse_reset_suppress_reboot_clear ]; then
     rm -rf /opt/secure/persistent/rdkservicestore
+    rm -rf /opt/secure/persistent/rdkservicestore-journal
 fi
 # authservice data cleanup
 if [ -d /opt/www/authService ]; then rm -rf /opt/www/authService/*; fi
@@ -246,6 +247,7 @@ if [ "$MODEL_NUM" = "pi" ] || [ "$DEVICE_TYPE" = "mediaclient" ];then
               result=$( curl -H "Content-Type: application/json"  -H "Authorization: Bearer $t" -X POST -d '{"jsonrpc":"2.0", "id":3, "method":"org.rdk.PersistentStore.1.setValue", "params":{"namespace":"FactoryTest", "key":"FTAClearStatus", "value":"CLEAR_COMPLETED"}}' http://127.0.0.1:9998/jsonrpc )
               echo "Warehouse_clear set value: $result"
 	      rm -rf /opt/secure/persistent/rdkservicestoreos-release
+              rm -rf /opt/secure/persistent/rdkservicestore-journal
               rm -f /tmp/warehouse_reset_suppress_reboot_clear
          fi
          echo "Warehouse Reset:Deleting receiver.conf override"


### PR DESCRIPTION
Reason for change: Temporary -journal folder created by sqlite blocks it from creating a new database after reset. Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>