### PR TITLE
RDKEMW-3085: Add minidump support for rfcMgr

### DIFF
--- a/lib/rdk/core_shell.sh
+++ b/lib/rdk/core_shell.sh
@@ -257,7 +257,7 @@ else
           echo $corename >> /tmp/.rmf_crashed
           dumpFile
      elif [ "$1" = "tr69agent" ] || [ "$1" =  "tr69hostif" ] || [ "$1" = "runTR69HostIf" ] ||
-                [ "$1" = "tr69BusMain" ] || [ "$1" = "dimclient" ]; then
+                [ "$1" = "tr69BusMain" ] || [ "$1" = "dimclient" ] || [ "$1" = "rfcMgr" ]; then
           dumpFile
      elif [ "$1" = "nxserver" ]; then
          dumpFile


### PR DESCRIPTION
Reason for change: Add minidump support for rfcMgr
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)