### PR TITLE
Topic/rdkemw 3401 (#144)

### DIFF
--- a/lib/rdk/getDeviceDetails.sh
+++ b/lib/rdk/getDeviceDetails.sh
@@ -215,6 +215,7 @@ getModelNum()
 getManufacturer(){
            output=$(mfr_util --Manufacturer 2>&1)
            if [ -n "$output" ] && ! echo "$output" | grep -iq "failed"; then
+               output=$(echo $output | sed 's/ /_/g')
                echo "$output" | tee /tmp/.manufacturer
 	   else
                echo "UNKNOWN"


### PR DESCRIPTION
* RDKEMW-1144: sysint Turn key changes for RDK-E

Reason for change: sysint Turn key changes for RDK-E
Test Procedure: Refer JIRA
Risks: Medium
Priority: P1



* RDKEMW-1144: sysint Turn key changes for RDK-E

Reason for change: sysint Turn key changes for RDK-E
Test Procedure: Refer JIRA
Risks: Medium
Priority: P1



* RDKEMW-3401: fetch failure in telemetry2_0

Reason for change: fetch failure in telemetry2_0
Test Procedure: Refer JIRA
Risks: Low
Priority: P0



* RDKEMW-3401: fetch failure in telemetry2_0

Reason for change: fetch failure in telemetry2_0
Test Procedure: Refer JIRA
Risks: Low
Priority: P0



---------