### PR TITLE
ES1-2565 [ES1][R37.009][R36.011] PreviousReboot is seen with empty re…

### DIFF
--- a/lib/rdk/reboot-checker.sh
+++ b/lib/rdk/reboot-checker.sh
@@ -57,6 +57,7 @@ if [ "$1" = "shutdown" ];then
                 ;;
      esac
 elif [ "$1" = "bootup" ];then
+    echo "Reading Reboot information from rebootInfo.log file"
     last_reboot_file=""
     last_bootfile=$(find $PREV_LOG_PATH -name last_reboot)
     last_log_path=$(echo ${last_bootfile%/*})
@@ -90,7 +91,7 @@ elif [ "$1" = "bootup" ];then
           fi
     fi
 
-    echo "$(/bin/timestamp) PreviousRebootReason: $rebootReason" >> $LOG_FILE
+    echo "$(/bin/timestamp) PreviousRebootReason: $rebootReason" > $LOG_FILE
     echo "$(/bin/timestamp) PreviousRebootInitiatedBy: $rebootInitiatedBy" >> $LOG_FILE
     echo "$(/bin/timestamp) PreviousRebootTime: $rebootTime" >> $LOG_FILE
     echo "$(/bin/timestamp) PreviousCustomReason: $customReason" >> $LOG_FILE

--- a/systemd_units/reboot-reason-logger.service
+++ b/systemd_units/reboot-reason-logger.service
@@ -24,6 +24,7 @@ After=local-fs.target nvram.service previous-log-backup.service network-online.t
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/lib/rdk/reboot-checker.sh bootup
 
 [Install]


### PR DESCRIPTION
…ason (#172)

* Update reboot-checker.sh

* ES1-2565: PreviousReboot is seen with empty reason



Reason for change:Fix multiple entry in rebootinfo.log Test Procedure: Test reboot reason update
Risks: Low

* ES1-2565  PreviousReboot is seen with empty reason



Reason for change:Fix multiple entry in rebootinfo.log Test Procedure: Test reboot reason update
Risks: Low