### PR TITLE
RDK-55878 : Data Collection Through T2 Events For Components Logging To dcmscript.log And Milestone Eventing

### DIFF
--- a/lib/rdk/uploadSTBLogs.sh
+++ b/lib/rdk/uploadSTBLogs.sh
@@ -384,7 +384,7 @@ sendTLSSSRCodebigRequest()
     uploadLog "Curl return code: $TLSRet, http code: $http_code"
 
     if [ "$TLSRet" != 0 ]; then
-        t2CountNotify "LUCurlErr_split"
+        t2ValNotify "LUCurlErr_split" "$TLSRet"
     fi
     logTLSError $TLSRet "Codebig SSR" $FQDN
 }
@@ -668,7 +668,7 @@ HttpLogUpload()
         uploadLog "Curl return code: $ret, http code: $http_code"
 
         if [ "$ret" != 0 ]; then
-            t2CountNotify "LUCurlErr_split"
+            t2ValNotify "LUCurlErr_split" "$ret"
         fi
         rm $FILENAME
 
@@ -699,7 +699,7 @@ HttpLogUpload()
                 rm $FILENAME
 
                 if [ "$ret" != 0 ]; then
-                    t2CountNotify "LUCurlErr_split"
+                    t2ValNotify "LUCurlErr_split" "$ret"
                 fi
                 if [ "$ret" = "0" ] && [ "$http_code" = 200 ]; then
                       t2CountNotify "TEST_lu_success"


### PR DESCRIPTION
Reason for Change : Fixing LUCurlERR_split Marker as a Value Marker instead of count