### PR TITLE
RDKEMW-4148: Move NM Wifi credentials to secure path

### DIFF
--- a/lib/rdk/NM_Bootstrap.sh
+++ b/lib/rdk/NM_Bootstrap.sh
@@ -42,3 +42,6 @@ if [ -f $WIFI_WPA_SUPPLICANT_CONF ]; then
   fi
   sed -i '/network={/,/}/d' /opt/secure/wifi/wpa_supplicant.conf
 fi
+
+mkdir -p /opt/secure/NetworkManager/system-connections
+cp /opt/NetworkManager/system-connections/* /opt/secure/NetworkManager/system-connections/


### PR DESCRIPTION
Reason for change: Pre-requisite for moving NM connection profiles
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)