### PR TITLE
RDKEMW-6113-Port the reboot script changes in RDK-V to RDK-E

### DIFF
--- a/lib/rdk/rebootNow.sh
+++ b/lib/rdk/rebootNow.sh
@@ -344,7 +344,7 @@ setPreviousRebootInfo()
     echo "\"otherReason\":\"$other\"" >> $REBOOT_INFO_FILE
     echo "}" >> $REBOOT_INFO_FILE
 
-    echo "PreviousRebootInfo:$timestamp,$customReason,$source,$reason" >> $PARODUS_REBOOT_INFO_FILE
+    echo "PreviousRebootInfo:$timestamp,$custom,$source,$reason" >> $PARODUS_REBOOT_INFO_FILE
     rebootLog "${FUNCNAME[0]}: Updated Reboot Reason information in $REBOOT_INFO_FILE and $PARODUS_REBOOT_INFO_FILE"
 }
 

--- a/lib/rdk/update_previous_reboot_info.sh
+++ b/lib/rdk/update_previous_reboot_info.sh
@@ -92,14 +92,15 @@ setPreviousRebootInfo()
     echo "}" >> $PREVIOUS_REBOOT_INFO_FILE
 
     rebootLog "Updating previous reboot reason in $PARODUS_LOG"
-   if ! grep -q "PreviousRebootInfo" "$PARODUS_REBOOT_INFO_FILE"; then
-       echo "Updating previous reboot info to Parodus" >> "$PARODUS_LOG"
-       echo "$(/bin/timestamp): $0: PreviousRebootInfo:$timestamp,$custom,$source,$reason" >> "$PARODUS_LOG"
-       echo "data uploaded successfully with PreviousRebootInfo" >> "$PARODUS_LOG"
-       rebootLog "$(/bin/timestamp): $0: PreviousRebootInfo:$timestamp,$custom,$source,$reason"
-   else
-       rebootLog "${FUNCNAME[0]}: Reboot info already present in $PARODUS_REBOOT_INFO_FILE, skipping update"
-   fi
+    existing_reboot_info=$(grep "PreviousRebootInfo" "$PARODUS_LOG" 2>/dev/null | tail -1)
+
+    if [ -z "$existing_reboot_info" ]; then
+        echo "$(/bin/timestamp): $0: Updating previous reboot info to Parodus" >> "$PARODUS_LOG"
+        echo "$(/bin/timestamp): $0: PreviousRebootInfo:$timestamp,$custom,$source,$reason" >> "$PARODUS_LOG"
+        rebootLog "Reboot Information Updated to parodus log:$timestamp,$custom,$source,$reason"
+    else
+        rebootLog "${FUNCNAME[0]}: Reboot info already present in $PARODUS_LOG as $existing_reboot_info, skipping update"
+    fi
 
     # Set Hard Power reset time with timestamp
     if [ "$reason" == "HARD_POWER" ] || [ "$reason" == "POWER_ON_RESET" ] || [ "$reason" == "UNKNOWN_RESET" ] || [ ! -f "$PREVIOUS_HARD_REBOOT_INFO_FILE" ];then

--- a/lib/rdk/update_previous_reboot_info.sh
+++ b/lib/rdk/update_previous_reboot_info.sh
@@ -92,8 +92,14 @@ setPreviousRebootInfo()
     echo "}" >> $PREVIOUS_REBOOT_INFO_FILE
 
     rebootLog "Updating previous reboot reason in $PARODUS_LOG"
-    echo "`/bin/timestamp` Updating previous reboot info to Parodus" >> $PARODUS_LOG
-    echo "`/bin/timestamp` : $0: PreviousRebootInfo:$timestamp,$reason,$customReason,$source" >> $PARODUS_LOG
+   if ! grep -q "PreviousRebootInfo" "$PARODUS_REBOOT_INFO_FILE"; then
+       echo "Updating previous reboot info to Parodus" >> "$PARODUS_LOG"
+       echo "$(/bin/timestamp): $0: PreviousRebootInfo:$timestamp,$custom,$source,$reason" >> "$PARODUS_LOG"
+       echo "data uploaded successfully with PreviousRebootInfo" >> "$PARODUS_LOG"
+       rebootLog "$(/bin/timestamp): $0: PreviousRebootInfo:$timestamp,$custom,$source,$reason"
+   else
+       rebootLog "${FUNCNAME[0]}: Reboot info already present in $PARODUS_REBOOT_INFO_FILE, skipping update"
+   fi
 
     # Set Hard Power reset time with timestamp
     if [ "$reason" == "HARD_POWER" ] || [ "$reason" == "POWER_ON_RESET" ] || [ "$reason" == "UNKNOWN_RESET" ] || [ ! -f "$PREVIOUS_HARD_REBOOT_INFO_FILE" ];then


### PR DESCRIPTION
Port the reboot script changes in RDK-V to RDK-E

Reason for change: Optimizing the scripts to better trace the reason for reboots 
Test Procedure: Run basic sanity and check the reboot condition

Risks: Medium
Priority: P1


Signed-off-by: Vismal S Kumar <ajvismal@yahoo.com>