### PR TITLE
DELIA-68639: UPNP router details not fetched after boot

### DIFF
--- a/lib/rdk/NM_Dispatcher.sh
+++ b/lib/rdk/NM_Dispatcher.sh
@@ -75,7 +75,7 @@ if [ "x$interfaceName" != "x" ] && [ "$interfaceName" != "lo" ]; then
     fi
     if [[ "$interfaceName" == "wlan0" || "$interfaceName" == "eth0" ]]; then
        if [ "$interfaceStatus" == "dhcp6-change" ] || [ "$interfaceStatus" == "dhcp4-change" ]; then 
-           sh /lib/rdk/getRouterInfo.sh $interfaceName
+           sh /lib/rdk/getRouterInfo.sh $interfaceName $interfaceStatus
            NMdispatcherLog "getRouterInfo.sh"
        fi
     fi


### PR DESCRIPTION
Reason for change: Know whether script is invoked for Ipv4 or Ipv6
Also only 1 instance of routerDiscovery should be active for an interface.
Test Procedure: Check for gateway details in log file
Risks: Low
Signed-off-by: jincysaramma_sam@comcast.com