### PR TITLE
RDK-58741: Remove network dependency to make the service run earlier

### DIFF
--- a/systemd_units/gstreamer-cleanup.service
+++ b/systemd_units/gstreamer-cleanup.service
@@ -20,9 +20,8 @@
 [Unit]
 Description=Cleans up Gstreamer Registry
 
-After=local-fs.target nvram.service network-online.target
+After=local-fs.target nvram.service
 Before=swupdate.service wpeframework.service
-Requires=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Reason for change: gstreamer-cleanup.service doesn't need network to complete it's functionality .
Test Procedure: Boot the TV.
Risks: low