### PR TITLE
RDKEMW-7177: Update logrotate.service as timer based

### DIFF
--- a/systemd_units/logrotate.service
+++ b/systemd_units/logrotate.service
@@ -21,7 +21,6 @@
 Description=Log Rotation Timer Service (R)
 
 [Service]
-Type=forking
+Type=oneshot
 SyslogIdentifier=logrotate
-ExecStart=/usr/sbin/logrotate -s /tmp/logrotatedata.status /etc/logrotatedata.conf -l /opt/logs/logrotate.log
-Restart=always
+ExecStart=/usr/sbin/logrotate -s /tmp/logrotatedata.status /etc/logrotatedata.conf -l /opt/logs/logrotate.log --skip-state-lock


### PR DESCRIPTION
Reason for change: Opensource logrotate is not meant to be run as a Daemon. It increases memory consumption over long uptime. Starting logrotate as a oneshot service based on systemd timer.
Test Procedure: Build Image and check logrotate functionality
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)