### PR TITLE
RDKEMW-8162: Device is not connected to Internet when "Ethernet" cable is removed and device is auto connected to WiFi

### DIFF
--- a/lib/rdk/NM_Dispatcher.sh
+++ b/lib/rdk/NM_Dispatcher.sh
@@ -56,6 +56,20 @@ if [ "x$interfaceName" != "x" ] && [ "$interfaceName" != "lo" ]; then
 
         sh /lib/rdk/ipmodechange.sh $imode $interfaceName $ipaddr $gwip $interfaceName "metric" "add"
         echo "$DT_TIME ipmodechange.sh" >> /opt/logs/NMMonitor.log
+
+        # Restart dnsmasq if it's running under NetworkManager
+        DNSMASQ_PID_FILE="/var/run/NetworkManager/dnsmasq.pid"
+
+        if [ -f "$DNSMASQ_PID_FILE" ]; then
+            DNSMASQ_PID=$(cat "$DNSMASQ_PID_FILE")
+            if [ -n "$DNSMASQ_PID" ]; then
+                echo "$DT_TIME Killing dnsmasq PID $DNSMASQ_PID" >> /opt/logs/NMMonitor.log
+                kill -9 "$DNSMASQ_PID"
+            else
+                echo "$DT_TIME dnsmasq PID not running or invalid" >> /opt/logs/NMMonitor.log
+            fi
+        fi
+
     fi
     if [ "$interfaceName" == "wlan0" ]; then
         touch /tmp/wifi-on


### PR DESCRIPTION
Reason for change: Add fix to run commands in background
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)