### PR TITLE
RDKEMW-8359: Removed nmcli connect with WIFI in the bootstrap

### DIFF
--- a/lib/rdk/NM_Bootstrap.sh
+++ b/lib/rdk/NM_Bootstrap.sh
@@ -37,21 +37,6 @@ if [ -f $WIFI_WPA_SUPPLICANT_CONF ]; then
   else
     PSK=""
   fi
-
-  if [ -z "$( ls -A '/opt/NetworkManager/system-connections' )" ]; then
-      if [ -z $SSID ]; then
-          echo "`/bin/timestamp` :$0: No SSID found in supplicant conf" >>  /opt/logs/NMMonitor.log
-      else
-          if [ -z $PSK ]; then
-              #connect to wifi
-              nmcli conn add type wifi con-name $SSID autoconnect yes ifname wlan0 ssid $SSID
-              nmcli conn reload
-          else
-              #connect to wifi
-              nmcli conn add type wifi con-name $SSID autoconnect yes ifname wlan0 ssid $SSID wifi-sec.key-mgmt wpa-psk wifi-sec.psk $PSK
-              nmcli conn reload
-          fi
-      fi
-  fi
+  echo "`/bin/timestamp` :$0: Removed nmcli SSID connect" >>  /opt/logs/NMMonitor.log
   sed -i '/network={/,/}/d' /opt/secure/wifi/wpa_supplicant.conf
 fi


### PR DESCRIPTION
Reason for change: Removed the nmcli SSID connect, since IUI change is ready based on migration datastore file.
Test Procedure: None
Priority: P1
Risks: Medium