### PR TITLE
RDKE-921: Clean up the mitigation done for dnsmasq restart in Xumo TV Release

### DIFF
--- a/lib/rdk/NM_Dispatcher.sh
+++ b/lib/rdk/NM_Dispatcher.sh
@@ -56,20 +56,6 @@ if [ "x$interfaceName" != "x" ] && [ "$interfaceName" != "lo" ]; then
 
         sh /lib/rdk/ipmodechange.sh $imode $interfaceName $ipaddr $gwip $interfaceName "metric" "add"
         echo "$DT_TIME ipmodechange.sh" >> /opt/logs/NMMonitor.log
-
-        # Restart dnsmasq if it's running under NetworkManager
-        DNSMASQ_PID_FILE="/var/run/NetworkManager/dnsmasq.pid"
-
-        if [ -f "$DNSMASQ_PID_FILE" ]; then
-            DNSMASQ_PID=$(cat "$DNSMASQ_PID_FILE")
-            if [ -n "$DNSMASQ_PID" ]; then
-                echo "$DT_TIME Killing dnsmasq PID $DNSMASQ_PID" >> /opt/logs/NMMonitor.log
-                kill -TERM "$DNSMASQ_PID"
-            else
-                echo "$DT_TIME dnsmasq PID not running or invalid" >> /opt/logs/NMMonitor.log
-            fi
-        fi
-
     fi
     if [ "$interfaceName" == "wlan0" ]; then
         touch /tmp/wifi-on


### PR DESCRIPTION
Reason for change: dnsmasq should be able to recognize interfaces as and when they come up

Test Procedure: Build RDKE image and check connectivity scenarios.
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)