### PR TITLE
RDKEMW-16414: Replace type exec in NM_Bootstrap

### DIFF
--- a/systemd_units/NM_Bootstrap.service
+++ b/systemd_units/NM_Bootstrap.service
@@ -22,7 +22,7 @@ Wants=NetworkManager.service
 After=NetworkManager.service
 
 [Service]
-Type=exec
+Type=simple
 ExecStart= /bin/sh -c '/lib/rdk/NM_Bootstrap.sh'
 
 [Install]


### PR DESCRIPTION
Reason for change: Move type to simple for systemd v230
Test Procedure: Build RDKE image and check NM_Bootstrap functionality

Signed-off-by: [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)