### PR TITLE
RDKEMW-18537:System Boot performance measurement without rdk_milestones

### DIFF
--- a/lib/rdk/ipv6addressChange.sh
+++ b/lib/rdk/ipv6addressChange.sh
@@ -56,7 +56,7 @@ if [ "x$cmd" == "xadd" ] && [ "x$flags" == "xglobal" ]; then
    if [ ! -f /tmp/estb_ipv4 ] && [ ! -f /tmp/estb_ipv6 ];
    then
       if [ -f "$LOGMILESTONE_BIN" ]; then
-          $LOGMILESTONE_BIN "IP_ACQUISTION_COMPLETED:$ifc"
+          #$LOGMILESTONE_BIN "IP_ACQUISTION_COMPLETED:$ifc"
           if [ $ifc == "eth0" ]; then
               ifc_uptime=$(awk '{printf "%.0f", $1 * 1000}' /proc/uptime)
               t2ValNotify "btime_ipacqEth_split" "$ifc_uptime"

--- a/lib/rdk/xconfImageCheck.sh
+++ b/lib/rdk/xconfImageCheck.sh
@@ -380,9 +380,9 @@ sendTLSCodebigRequest()
 
     if [ "$1" == "XCONF" ]; then
         echo "Attempting $TLS connection to Codebig XCONF server"
-	if [ -f $LOGMILESTONE_BIN ];then
-            $LOGMILESTONE_BIN "CONNECT_TO_XCONF_CDL"
-        fi
+#	if [ -f $LOGMILESTONE_BIN ];then
+#            $LOGMILESTONE_BIN "CONNECT_TO_XCONF_CDL"
+#        fi
         if [ -f $EnableOCSPStapling ] || [ -f $EnableOCSP ]; then
            CURL_CMD="curl $TLS --cert-status --connect-timeout $CURL_TLS_TIMEOUT  -w '%{http_code}\n' -o \"$FILENAME\" \"$CB_SIGNED_REQUEST\" -m 10"      
         else

--- a/systemd_units/log-rdk-start.service
+++ b/systemd_units/log-rdk-start.service
@@ -27,7 +27,7 @@ DefaultDependencies=no
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/rdkLogMileStone "RDK_STARTED"
+#ExecStart=/usr/bin/rdkLogMileStone "RDK_STARTED"
 
 [Install]
 WantedBy=local-fs.target

--- a/systemd_units/notify-network-ready.service
+++ b/systemd_units/notify-network-ready.service
@@ -5,4 +5,5 @@ After=dbus.service
 [Service]
 Type=oneshot
 ExecStartPre=/bin/touch /tmp/connectivity_check_done
-ExecStart=/lib/rdk/logMilestone.sh "INTERNET_FULLY_CONNECTED"
+#ExecStart=/lib/rdk/logMilestone.sh "INTERNET_FULLY_CONNECTED"
+ExecStart=/bin/true

--- a/systemd_units/ntp-event.service
+++ b/systemd_units/ntp-event.service
@@ -25,5 +25,5 @@ ConditionPathExists=/tmp/clock-event
 Type=oneshot
 Environment="EVENT_NAME=NTPReceivedEvent"
 Environment="EVENT_VALUE=1"
-ExecStartPre= /bin/sh -c 'if [ ! -f /tmp/stt_received ];then /bin/touch /tmp/stt_received; if [ -f /usr/bin/rdkLogMileStone ];then /usr/bin/rdkLogMileStone "CONNECT_TO_NTP_SERVER"; fi; fi'
+ExecStartPre= /bin/sh -c 'if [ ! -f /tmp/stt_received ];then /bin/touch /tmp/stt_received; fi'
 ExecStart=/usr/bin/IARM_event_sender $EVENT_NAME $EVENT_VALUE


### PR DESCRIPTION
Reason for change: To measure System Boot performance measurement without rdk_milestone logs
Test Procedure: Boot the TV and check for rdk_milestones.log .It should not have any entries
Risks: low