### PR TITLE
RDK-61614: Remove Sensitive StringFrom Open Source

### DIFF
--- a/lib/rdk/startTunnel.sh
+++ b/lib/rdk/startTunnel.sh
@@ -45,15 +45,9 @@ case $oper in
                  echo "Error: GetConfigFile Not Found"
                  exit 127
              fi
-<<<<<<< HEAD
              GetConfigFile /tmp/webpa-user
              /usr/bin/ssh -i /tmp/webpa-user $*
              rm /tmp/webpa-user
-=======
-             GetConfigFile /tmp/webpa-user
-             /usr/bin/ssh -i /tmp/webpa-user $*
-             rm /tmp/webpa-user
->>>>>>> 26f6cf5 (RDK-61614: Remove Sensitive StringFrom Open Source)
              exit 1
              ;;
            stop)

--- a/lib/rdk/startTunnel.sh
+++ b/lib/rdk/startTunnel.sh
@@ -45,9 +45,9 @@ case $oper in
                  echo "Error: GetConfigFile Not Found"
                  exit 127
              fi
-             GetConfigFile /tmp/nvgeajacl.ipe
-             /usr/bin/ssh -i /tmp/nvgeajacl.ipe $*
-             rm /tmp/nvgeajacl.ipe
+             GetConfigFile /tmp/webpa-key.ipe
+             /usr/bin/ssh -i /tmp/webpa-key.ipe $*
+             rm /tmp/webpa-key.ipe
              exit 1
              ;;
            stop)

--- a/lib/rdk/startTunnel.sh
+++ b/lib/rdk/startTunnel.sh
@@ -45,9 +45,15 @@ case $oper in
                  echo "Error: GetConfigFile Not Found"
                  exit 127
              fi
-             GetConfigFile /tmp/webpa-key.ipe
-             /usr/bin/ssh -i /tmp/webpa-key.ipe $*
-             rm /tmp/webpa-key.ipe
+<<<<<<< HEAD
+             GetConfigFile /tmp/webpa-user
+             /usr/bin/ssh -i /tmp/webpa-user $*
+             rm /tmp/webpa-user
+=======
+             GetConfigFile /tmp/webpa-user
+             /usr/bin/ssh -i /tmp/webpa-user $*
+             rm /tmp/webpa-user
+>>>>>>> 26f6cf5 (RDK-61614: Remove Sensitive StringFrom Open Source)
              exit 1
              ;;
            stop)


### PR DESCRIPTION
Reason for change: Remove Sensitive String (pattern132) From Open Source
Test Procedure: Tested the tasks locally
Risks: Low
Signed-off-by: Aruna_Appikatla@comcast.com