### PR TITLE
RDKEMW-23121: Use vendor functions if available

### DIFF
--- a/lib/rdk/getDeviceDetails.sh
+++ b/lib/rdk/getDeviceDetails.sh
@@ -45,9 +45,6 @@ logMsg "enter"
 . /etc/include.properties
 . /etc/device.properties
 . $RDK_PATH/utils.sh
-if [ -f /lib/rdk/utils-vendor.sh ]; then
-    . $RDK_PATH/utils-vendor.sh
-fi
 
 
 if [ "$DEVICE_TYPE" != "mediaclient" ]; then

--- a/lib/rdk/utils.sh
+++ b/lib/rdk/utils.sh
@@ -282,9 +282,3 @@ getPrivacyControlMode()
     #Implement own logic to get the privicyMode settings
     return
 }
-
-# use device specific functions, if available
-# eg: getEstbMacAddress has device specific implementations
-if [ -f $RDK_PATH/utils-vendor.sh ]; then
-    . $RDK_PATH/utils-vendor.sh
-fi

--- a/lib/rdk/utils.sh
+++ b/lib/rdk/utils.sh
@@ -285,6 +285,6 @@ getPrivacyControlMode()
 
 # use device specific functions, if available
 # eg: getEstbMacAddress has device specific implementations
-if [ -f /lib/rdk/utils-vendor.sh ]; then
+if [ -f $RDK_PATH/utils-vendor.sh ]; then
     . $RDK_PATH/utils-vendor.sh
 fi

--- a/lib/rdk/utils.sh
+++ b/lib/rdk/utils.sh
@@ -282,3 +282,9 @@ getPrivacyControlMode()
     #Implement own logic to get the privicyMode settings
     return
 }
+
+# use device specific functions, if available
+# eg: getEstbMacAddress has device specific implementations
+if [ -f /lib/rdk/utils-vendor.sh ]; then
+    . $RDK_PATH/utils-vendor.sh
+fi


### PR DESCRIPTION
Modified to use device specific overrides. Xi6 devices fetch getEstbMacAddress differently