### PR TITLE
RDKEMW-23121: Use vendor functions if available (#597)

### DIFF
--- a/lib/rdk/getDeviceDetails.sh
+++ b/lib/rdk/getDeviceDetails.sh
@@ -45,9 +45,6 @@ logMsg "enter"
 . /etc/include.properties
 . /etc/device.properties
 . $RDK_PATH/utils.sh
-if [ -f /lib/rdk/utils-vendor.sh ]; then
-    . $RDK_PATH/utils-vendor.sh
-fi
 
 
 if [ "$DEVICE_TYPE" != "mediaclient" ]; then


### PR DESCRIPTION
* RDKEMW-23121: Use vendor functions if available

Modified to use device specific overrides. Xi6 devices fetch getEstbMacAddress differently

* RDKEMW-23121: Use vendor functions if available

* RDKEMW-23121: moved the override to utils.sh

* Update utils.sh